### PR TITLE
Add logo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# SugarSS [![Build Status][ci-img]][ci]
+<img height="200" src="http://corysimmons.github.io/sugarss/sugarcss-logo.svg">
+
+[![Build Status][ci-img]][ci]
 
 <img align="right" width="135" height="95"
      title="Philosopher’s stone, logo of PostCSS"


### PR DESCRIPTION
Need to update repo name/npm package to `sugarcss` or `sugar-css`.

Need to update my README change to reflect your version of the logo.

It'd be nicer if the logo was in gh-pages so it didn't clutter master.