### PR TITLE
Remove deprecated Atom package

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,14 +123,13 @@ So you must write a space after property name: `color: black` is good,
 
 ## Text Editors
 
-* Atom: [language-postcss] or [language-postcss-sugarss] and [source-preview-postcss]
+* Atom: [language-postcss] and [source-preview-postcss]
 * Vim: [vim-sugarss]
 
 We are working on syntax highlight support in text editors.
 
 Right now, you can set `Sass` or `Stylus` syntax highlight for `.sss` files.
 
-[language-postcss-sugarss]: https://atom.io/packages/language-postcss-sugarss
 [language-postcss]:         https://atom.io/packages/language-postcss
 [source-preview-postcss]:   https://atom.io/packages/source-preview-postcss
 [vim-sugarss]:              https://github.com/hhsnopek/vim-sugarss


### PR DESCRIPTION
Atom [language-postcss-sugarss](https://atom.io/packages/language-postcss-sugarss) plugin is deprecated