### PR TITLE
Add installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ or use it without any PostCSS plugins.
 [ci-img]:               https://img.shields.io/travis/postcss/sugarss.svg
 [ci]:                   https://travis-ci.org/postcss/sugarss
 
+## Installation
+
+```bash
+npm install sugarss --save-dev
+```
+
 ## Syntax
 
 SugarSS MIME-type is `text/x-sugarss` with `.sss` file extension.


### PR DESCRIPTION
Seems to be a convention that there are no installation instructions for syntax parsers.
If this is not accepted please explain why.

Thank you and look forward to contributing more!