### PR TITLE
postcss as a peer dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ Then create `.postcssrc` file:
 [`postcss-cli`]: https://github.com/postcss/postcss-cli
 [Parcel]: https://parceljs.org/transforms.html
 
+**Note**: you should include postcss@7 into devDependencies of your project manually. postcss tooling packages require it as a peer and does not install it to avoid swallowing the typical node_modules directory.
+
 ### Imports
 
 If you doesn’t use Webpack or Parcel, you need some PostCSS plugin

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "author": "Andrey Sitnik <andrey@sitnik.ru>",
   "license": "MIT",
   "repository": "postcss/sugarss",
-  "dependencies": {
-    "postcss": "^7.0.14"
+  "peerDependencies": {
+    "postcss": "7"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
@@ -37,6 +37,7 @@
     "husky": "^1.3.1",
     "jest": "^24.1.0",
     "lint-staged": "^8.1.4",
+    "postcss": "^7.0.14"
     "postcss-parser-tests": "^6.3.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "husky": "^1.3.1",
     "jest": "^24.1.0",
     "lint-staged": "^8.1.4",
-    "postcss": "^7.0.14"
+    "postcss": "^7.0.14",
     "postcss-parser-tests": "^6.3.1"
   },
   "scripts": {


### PR DESCRIPTION
every project, that use postcss tooling has a postcss self

because every package requires postcss himself, my project has about 10 postcss installations every with own version.